### PR TITLE
Updated link to detailed manuscript.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -230,4 +230,4 @@ intersphinx_mapping = {
 # extlinks
 extlinks = {'arxiv': ('https://arxiv.org/abs/%s', 'arXiv:'),
             'doi': ('https://dx.doi.org/%s', 'doi:'),
-            'manual': ('https://confluence.dwavesys.com/download/attachments/89501105/manuscript.pdf?version=3&modificationDate=1628901443175&api=v2/%s', '')}
+            'manual': ('https://arxiv.org/abs/2110.01647/%s', '')}


### PR DESCRIPTION
Previously, the library's documentation linked to a detailed manuscript that was inaccessible to the public. The detailed manuscript has since been published on the arXiv, so I have updated the link accordingly.